### PR TITLE
Update README.md, Fixed docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ following caveats or exceptions:
 ## Resources
 
 * [PyPI Project](https://pypi.org/project/hyperscan/)
-* [Documentation](https://python-hyperscan.rtfm.io)
+* [Documentation](https://python-hyperscan.readthedocs.io)
 * [Hyperscan C API Documentation](http://intel.github.io/hyperscan/dev-reference/)
 
 


### PR DESCRIPTION
rtfm.io domain doesn't work any more, It's for sale now
I changed documentation's URL to use readthedocs.io Domain instead of that!