### PR TITLE
Add setuptools to build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,5 +54,5 @@ python = "^3.5"
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["setuptools", "poetry>=0.12"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
This hopefully fixes the `ModuleNotFoundError: No module named 'setuptools'` error described in #14 when running `pip install hyperscan`.

I found this suggested fix on the poetry repo [here](https://github.com/python-poetry/poetry/issues/3153#issuecomment-727196619). I don't really understand how pip/poetry/setuptools are interacting here or whether this is the right fix, but it seems to work.