### PR TITLE
Fix missing error constants

### DIFF
--- a/src/hyperscan/hyperscanmodule.c
+++ b/src/hyperscan/hyperscanmodule.c
@@ -31,7 +31,10 @@
     return rv;                                        \
   }
 #define ADD_HYPERSCAN_ERROR(module, errors, base, name, hs_err, doc) \
-  ADD_INT_CONSTANT(module, hs_err);                                  \
+  if (PyModule_AddIntConstant(module, #hs_err, hs_err) < 0) {        \
+    Py_XDECREF(module);                                              \
+    return NULL;                                                     \
+  }                                                                  \
   PyObject *name =                                                   \
     PyErr_NewExceptionWithDoc("hyperscan." #name, doc, base, NULL);  \
   if (name == NULL) {                                                \


### PR DESCRIPTION
`hyperscan.HS_INVALID` and other error constants are no longer available. Instead some odd constants are exposed:

```
>>> import hyperscan
>>> hyperscan.HS_INVALID
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'hyperscan' has no attribute 'HS_INVALID'
>>> print("\n".join(dir(hyperscan)))
(-1)
(-10)
(-11)
(-12)
(-13)
(-2)
(-3)
(-32)
(-4)
(-5)
(-6)
(-7)
(-8)
(-9)
ArchitectureError
BadAlignError
BadAllocationError
CH_BAD_ALIGN
CH_BAD_ALLOC
CH_COMPILER_ERROR
CH_DB_MODE_ERROR
(...)
```

Calling `ADD_INT_CONSTANT()` inside `ADD_HYPERSCAN_ERROR()` expands `hs_err` too early, causing `ADD_INT_CONSTANT()` to declare the *value* of the constant instead of its name.

Duplicate the content of `ADD_INT_CONSTANT()` to fix this.

With this change we get this:

```
>>> import hyperscan
>>> hyperscan.HS_INVALID
-1
>>> print("\n".join(dir(hyperscan)))
ArchitectureError
BadAlignError
BadAllocationError
CH_BAD_ALIGN
CH_BAD_ALLOC
CH_COMPILER_ERROR
CH_DB_MODE_ERROR
CH_DB_PLATFORM_ERROR
CH_DB_VERSION_ERROR
(...)
```
