### PR TITLE
Add py.typed marker for static type analyzers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include *.rst
 recursive-include docs *
 recursive-include examples *
-recursive-include src/hyperscan *.c *.cpp *.h *.pyx *.pxd *.pxi
+recursive-include src/hyperscan *.c *.cpp *.h *.pyx *.pxd *.pxi py.typed
 include COPYING
 include README.md
 include README.rst


### PR DESCRIPTION
The project has typing information already, but it is now available to type checkers when the library is imported.

`py.typed` file fixes it.