### PR TITLE
extension: guard against NULL / PyNone scratch in Database_dealloc

### DIFF
--- a/src/hyperscan/extension.c
+++ b/src/hyperscan/extension.c
@@ -151,14 +151,18 @@ static void Database_dealloc(Database *self)
 {
   if (self->chimera) {
     ch_free_database(self->ch_db);
-    ch_scratch_t *scratch = ((Scratch *)self->scratch)->ch_scratch;
-    if (scratch != NULL)
-      ch_free_scratch(scratch);
+    if (self->scratch != Py_None && self->scratch != NULL) {
+      ch_scratch_t *scratch = ((Scratch *)self->scratch)->ch_scratch;
+      if (scratch)
+        ch_free_scratch(scratch);
+    }
   } else {
     hs_free_database(self->hs_db);
-    hs_scratch_t *scratch = ((Scratch *)self->scratch)->hs_scratch;
-    if (scratch != NULL)
-      hs_free_scratch(scratch);
+    if (self->scratch != Py_None && self->scratch != NULL) {
+      hs_scratch_t *scratch = ((Scratch *)self->scratch)->hs_scratch;
+      if (scratch)
+        hs_free_scratch(scratch);
+    }
   }
 
   Py_TYPE(self)->tp_free((PyObject *)self);


### PR DESCRIPTION
Database_dealloc unconditionally cast `self->scratch` to a Scratch object and dereferenced it in order to free the underlying hs_scratch_t/ch_scratch_t buffer.

If the Database was created without calling `alloc_scratch()` (or if the `scratch` attribute had been overwritten from Python), `self->scratch` could be either NULL or Py_None, leading to an immediate SIGSEGV when the object was garbage-collected.

This adds an explicit `self->scratch != NULL && self->scratch != PyNone` check before dereferencing the pointer on both the Hyperscan and Chimera code paths. The scratch space is still released when present, but we no longer crash when it is absent.

---

This was happening with Python 3.12 compiled via `pyenv` when using the wheel on macOS 15.5. I was not able to reproduce the issue when compiling the entire project from source on Python 3.13.

With that said, I completely disassembled the shared library, and validated that this was why/how it was happening.