### PR TITLE
Fix memory leak in ch_match_handler & hold GIL during Py_DECREF calls

### DIFF
--- a/src/hyperscan/extension.c
+++ b/src/hyperscan/extension.c
@@ -101,8 +101,8 @@ static int hs_match_handler(
     halt = rv == Py_None ? 0 : PyObject_IsTrue(rv);
     cctx->success = 1;
   }
-  PyGILState_Release(gstate);
   Py_XDECREF(rv);
+  PyGILState_Release(gstate);
   return halt;
 }
 
@@ -142,8 +142,8 @@ static int ch_match_handler(
     halt = rv == Py_None ? 0 : PyObject_IsTrue(rv);
     cctx->success = 1;
   }
-  PyGILState_Release(gstate);
   Py_XDECREF(rv);
+  PyGILState_Release(gstate);
   return halt;
 }
 

--- a/src/hyperscan/extension.c
+++ b/src/hyperscan/extension.c
@@ -143,6 +143,7 @@ static int ch_match_handler(
     cctx->success = 1;
   }
   Py_XDECREF(rv);
+  Py_XDECREF(ocaptured);
   PyGILState_Release(gstate);
   return halt;
 }


### PR DESCRIPTION
`ocaptured` was never getting freed by the Python interpreter as the reference count never hits 0.

As well, calls to Py_XDECREF were happening _after_ the GIL was released, which wasn't exposed as an issue until the needed `Py_XDECREF` call on `ocaptured` was added.