### PR TITLE
fix: make loadb mode parameter optional with HS_MODE_BLOCK default

### DIFF
--- a/src/hyperscan/extension.c
+++ b/src/hyperscan/extension.c
@@ -1312,7 +1312,8 @@ static PyMethodDef HyperscanMethods[] = {
    "    Args:\n"
    "        buf (:obj:`bytearray`): A serialized Hyperscan database.\n"
    "        mode (int, optional): The expected mode of the database.\n"
-   "            Defaults to :const:`HS_MODE_BLOCK` for backward compatibility.\n\n"
+   "            Defaults to :const:`HS_MODE_BLOCK` for backward "
+   "compatibility.\n\n"
    "    Returns:\n"
    "        :class:`Database`: The deserialized database instance.\n\n"},
   {NULL}};

--- a/src/hyperscan/extension.c
+++ b/src/hyperscan/extension.c
@@ -1274,8 +1274,11 @@ static PyObject *loadb(PyObject *self, PyObject *args, PyObject *kwds)
   odb = PyObject_CallFunctionObjArgs((PyObject *)&DatabaseType, NULL);
   Database *db = (Database *)odb;
 
+  // Default to HS_MODE_BLOCK for backward compatibility
+  db->mode = HS_MODE_BLOCK;
+
   static char *kwlist[] = {"buf", "mode", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwds, "OI", kwlist, &obuf, &db->mode))
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|I", kwlist, &obuf, &db->mode))
     return NULL;
   if (!PyBytes_Check(obuf)) {
     PyErr_SetString(PyExc_TypeError, "buf must be a bytestring");
@@ -1304,11 +1307,12 @@ static PyMethodDef HyperscanMethods[] = {
   {"loadb",
    (PyCFunction)loadb,
    METH_VARARGS | METH_KEYWORDS,
-   "loadb(buf, mode)\n"
+   "loadb(buf, mode=HS_MODE_BLOCK)\n"
    "    Deserializes a Hyperscan database.\n\n"
    "    Args:\n"
    "        buf (:obj:`bytearray`): A serialized Hyperscan database.\n"
-   "        mode (int): The expected mode of the database.\n\n"
+   "        mode (int, optional): The expected mode of the database.\n"
+   "            Defaults to :const:`HS_MODE_BLOCK` for backward compatibility.\n\n"
    "    Returns:\n"
    "        :class:`Database`: The deserialized database instance.\n\n"},
   {NULL}};

--- a/tests/test_hyperscan.py
+++ b/tests/test_hyperscan.py
@@ -323,6 +323,20 @@ def test_literal_expressions(mocker):
     assert callback.mock_calls == expected
 
 
+def test_loadb_backward_compatibility():
+    """Test that loadb works without mode parameter (issue #152)."""
+    db = hyperscan.Database()
+    db.compile(expressions=[b"test"], ids=[0])
+    
+    serialized = hyperscan.dumpb(db)
+    
+    db_loaded = hyperscan.loadb(serialized)
+    assert db_loaded.mode == hyperscan.HS_MODE_BLOCK
+    
+    db_loaded_explicit = hyperscan.loadb(serialized, mode=hyperscan.HS_MODE_BLOCK)
+    assert db_loaded_explicit.mode == hyperscan.HS_MODE_BLOCK
+
+
 def test_unicode_expressions():
     """Test unicode pattern compilation and scanning (issue #207).
     


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #211

## Chain of upstream PRs as of 2025-07-12

* PR #211:
  `main` ← `chore/cleanup-config-files`

  * **PR #212 (THIS ONE)**:
    `chore/cleanup-config-files` ← `fix/152-loadb-mode-parameter`

<!-- end git-machete generated -->

Resolves issue #152 where loadb() requires mandatory mode parameter,
breaking backward compatibility from v0.5.0.

Changes:
- Make mode parameter optional in loadb() function signature
- Default to HS_MODE_BLOCK for backward compatibility
- Update docstring to reflect optional parameter
- Add test for backward compatibility

The mode parameter can still be explicitly provided when needed,
but existing code that doesn't specify mode will work again.