### PR TITLE
fix: suppress clang unqualified-std-cast-call warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,7 @@ jobs:
         include:
           # 🐧 manylinux x86_64
           - os: ubuntu-24.04
-            python: "3.10"
+            python: "3.11"
             python_id: cp310
             platform_id: manylinux_x86_64
           - os: ubuntu-24.04
@@ -212,7 +212,7 @@ jobs:
 
           # 🐧 manylinux aarch64
           - os: ubuntu-24.04-arm
-            python: "3.10"
+            python: "3.11"
             python_id: cp310
             platform_id: manylinux_aarch64
           - os: ubuntu-24.04-arm
@@ -230,19 +230,19 @@ jobs:
 
           # 🐧 manylinux2014 PyPy x86_64
           - os: ubuntu-24.04
-            python: "3.10"
+            python: "3.11"
             python_id: pp310
             platform_id: manylinux_x86_64
 
           # 🐧 manylinux2014 PyPy ARM
           - os: ubuntu-24.04-arm
-            python: "3.10"
+            python: "3.11"
             python_id: pp310
             platform_id: manylinux_aarch64
 
           # 🦀 musllinux x86_64
           - os: ubuntu-24.04
-            python: "3.10"
+            python: "3.11"
             python_id: cp310
             platform_id: musllinux_x86_64
           - os: ubuntu-24.04
@@ -260,7 +260,7 @@ jobs:
 
           # 🦀 musllinux ARM
           - os: ubuntu-24.04-arm
-            python: "3.10"
+            python: "3.11"
             python_id: cp310
             platform_id: musllinux_aarch64
           - os: ubuntu-24.04-arm
@@ -278,7 +278,7 @@ jobs:
 
           # 🍎 macOS x86_64
           - os: macos-13
-            python: "3.10"
+            python: "3.11"
             python_id: cp310
             platform_id: macosx_x86_64
           - os: macos-13
@@ -296,7 +296,7 @@ jobs:
 
           # 🍎 macOS arm64 (Apple silicon)
           - os: macos-15
-            python: "3.10"
+            python: "3.11"
             python_id: cp310
             platform_id: macosx_arm64
           - os: macos-15
@@ -314,7 +314,7 @@ jobs:
 
           # 🪟 Windows x86_64
           - os: windows-2025
-            python: "3.10"
+            python: "3.11"
             python_id: cp310
             platform_id: win_amd64
           - os: windows-2025

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,8 +227,15 @@ if(HS_BUILD_REQUIRED)
       set(HS_CMAKE_COMMON_FLAGS "-fPIC")
     endif()
     
+    
     set(HS_CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${HS_CMAKE_COMMON_FLAGS}")
     set(HS_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${HS_CMAKE_COMMON_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
+    
+    # Add clang warning suppression for vectorscan builds
+    if(USE_VECTORSCAN AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER MATCHES "[Cc]lang.*"))
+      set(HS_CMAKE_CXX_FLAGS "${HS_CMAKE_CXX_FLAGS} -Wno-unqualified-std-cast-call")
+    endif()
+    
     set(HS_CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
     set(HS_GENERATOR "Unix Makefiles")
   endif()
@@ -432,7 +439,7 @@ if(HS_BUILD_REQUIRED)
     STAMP_DIR ${hyperscan_STAMP_DIR}
     INSTALL_COMMAND ""
     CMAKE_GENERATOR ${HS_GENERATOR}
-    CMAKE_ARGS ${HS_CMAKE_ARGS}
+    CMAKE_ARGS ${HS_CMAKE_ARGS} -Wno-dev
     BUILD_BYPRODUCTS ${HS_BUILD_BYPRODUCTS}
     BUILD_COMMAND ${CMAKE_COMMAND} --build . --config Release --parallel 4 ${HS_TARGETS}
   )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ test-command = "pytest --pyargs {package}/tests -vvv"
 test-requires = ["pytest>=7.0", "pytest-mock"]
 # Will avoid testing on emulated architectures and macOS Apple silicon
 test-skip = "*-*linux_{ppc64le,s390x} *-macosx_arm64"
+enable = ["pypy"]
 
 [tool.cibuildwheel.linux]
 before-all = ["yum -y update", """yum -y install \


### PR DESCRIPTION
newer clang versions error on unqualified std::move in vectorscan chimera code, this suppresses the warning to fix musl/macos builds