### PR TITLE
chore(changelog): filter CI-scoped commits from release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,7 @@
 
-## v0.7.29 — 2025-11-30
+## v0.7.29 — 2025-12-02
 ### Fixes
-- force push when moving release tags (#239)
-
-
-
-## v0.7.29 — 2025-11-30
-### Fixes
-- resolve type aliasing bug causing missed matches (#202) (#234)
-- retag merge commits so tags appear in main history (#235)
-- use angular parser for conventional commits (#236)
-- remove emoji parser config for angular parser (#237)
+- resolve type aliasing bug causing missed matches in vectored scanning (#234)
 
 ## v0.7.28 — 2025-10-22
 ### Docs

--- a/cliff.toml
+++ b/cliff.toml
@@ -10,6 +10,11 @@ skip_commit = [
 ]
 commit_parsers = [
   { message = "^feat", group = "Features" },
+  # Skip CI-scoped commits regardless of type (fix(ci), chore(ci), etc.)
+  { message = "^\\w+\\(ci\\)", skip = true },
+  { message = "^\\w+\\(publish\\)", skip = true },
+  { message = "^\\w+\\(release\\)", skip = true },
+  { message = "^\\w+\\(build\\)", skip = true },
   { message = "^fix", group = "Fixes" },
   { message = "^perf", group = "Performance" },
   { message = "^refactor", group = "Refactors" },


### PR DESCRIPTION
- adds skip rules for `fix(ci)`, `fix(publish)`, etc scopes
- cleans up duplicate 0.7.29 entries